### PR TITLE
[Fix] for Euphonic v0.3.0 and brilleu v0.2.1

### DIFF
--- a/+brillem/@Euphonic/horace_sqw.m
+++ b/+brillem/@Euphonic/horace_sqw.m
@@ -33,7 +33,7 @@ function sqw = horace_sqw(obj,qh,qk,ql,en,input_pars,varargin)
 %              Some keywords control aspects of this function:
 %              'coordtrans' - a matrix to transform the input coordinates
 %                             (qh,qk,ql,en) before being sent to the
-%                             py.brille.euphonic.BrEu object's method.
+%                             py.brille.euphonic.BrillEu object's method.
 %                             [default: eye(4) % identity]
 %
 %              Any additional keyword parameters will be passed to SymSim
@@ -90,6 +90,12 @@ matkeys.sizes = {[4,4]};
 assert(ismatrix(input_pars) && isnumeric(input_pars), 'Numeric matrix input parameters are required')
 
 nQ = numel(qh);
+memmult = 11; % Fudge-factor based on NDLT1145 (Win10, 32GB RAM)
+excess_bytes = brillem.excess_memory(obj.pyobj.grid, nQ, memmult);
+if excess_bytes < 0
+    error('Not enough free memory! Estimated shortfall %g bytes',excess_bytes);
+end
+
 inshape = size(qh);
 if size(qh,1) ~= nQ
     qh = qh(:);
@@ -138,7 +144,7 @@ dict.temperature = temp;
 if ~isempty(pars)
     dict.param = pars;
 end
-sqw = brillem.p2m( obj.pyobj.s_qw(Q, brille.m2p(en), py.dict(dict)) );
+sqw = brillem.p2m( obj.pyobj.s_qw(Q, brillem.m2p(en), py.dict(dict)) );
 
 if size(sqw) ~= inshape
   sqw = reshape(sqw, inshape);

--- a/+brillem/@Euphonic/w_q.m
+++ b/+brillem/@Euphonic/w_q.m
@@ -55,9 +55,9 @@ if sum(sum(abs(kwds.coordtrans - eye(4)))) > 0
     ql = sum(bsxfun(@times, kwds.coordtrans(3,:), qc),2);
     clear qc;
 end
-Q = brille.m2p(cat(2,qh,qk,ql));
+Q = brillem.m2p(cat(2,qh,qk,ql));
 
-wq = brille.p2m(obj.pyobj.w_q(Q, py.dict(dict)));
+wq = brillem.p2m(obj.pyobj.w_q(Q, py.dict(dict)));
 
 wq_size = size(wq);
 if wq_size(1:end-1) ~= inshape

--- a/+brillem/excess_memory.m
+++ b/+brillem/excess_memory.m
@@ -1,0 +1,47 @@
+% brillem -- a MATLAB interface for brille
+% Copyright 2020 Greg Tucker
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% This program is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+function excess = excess_memory(pygrid, npts, multiplier)
+if nargin < 3 || isempty(multiplier); multiplier = 1; end
+excess = freeBytes() - multiplier*npts*brillem.p2m(pygrid.bytes_per_point);
+end
+
+% Adapted from spinW sw_freemem:
+function fb = freeBytes()
+    fb = 0;
+    if ismac
+        % read free memory on a macOS machine
+        [~,memStr] = unix('vm_stat | grep free');
+        fb = sscanf(memStr(14:end),'%f')*4096;
+    elseif isunix
+        % read free memeory on a linux machine
+        [~, memStr] = unix('free -b | grep ''-''');
+        if isempty(memStr)
+            % there is no buffer/cache, just get the 'Mem' values
+            [~, memStr] = unix('free -b | grep ''Mem''');
+            [~, mem_free] = strtok(memStr);
+            mem = sscanf(mem_free,'%f');
+            fb = mem(3);
+        else
+            [~, mem_free] = strtok(memStr(20:end));
+            fb = str2double(mem_free);
+        end
+    elseif ispc
+        % use built-in MATLAB functionality to read memory on a Windows machine
+        uv = memory();
+        fb = uv.MaxPossibleArrayBytes;
+    end
+end

--- a/+brillem/readparam.m
+++ b/+brillem/readparam.m
@@ -14,7 +14,7 @@
 % You should have received a copy of the GNU General Public License
 % along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-% This function is a sw_readparam from spinw modified to take an empty
+% This function is sw_readparam from spinw modified to take an empty
 % format struct and also to return all key-value pairs not in format.
 
 function [input, extras] = readparam(format, varargin)
@@ -101,15 +101,15 @@ usedField = false(1,numel(rName));
 
 % Go through all fields.
 for ii = 1:length(fName)
-    
+
     rawIdx = find(strcmpi(rName,fName{ii}));
-    
+
     if any(rawIdx)
         rawIdx = rawIdx(1);
         usedField(rawIdx) = true;
-        
+
         inputValid = true;
-        
+
         % Go through all dimension of the selected field to check size.
         if isfield(format, 'sizes')
             for jj = 1:length(format.sizes{ii})
@@ -124,7 +124,7 @@ for ii = 1:length(fName)
                         if storeSize(-format.sizes{ii}(jj)) ~= size(raw.(rName{rawIdx}),jj)
                             inputValid = false;
                         end
-                        
+
                     end
                 end
             end


### PR DESCRIPTION
Fixes #2
- The new brilleu interface for Euphonic v0.3.0 requires mirrored
  modifications to +brillem.@Euphonic to handle the `.from_castep` and
  `.from_phonopy` initializers.
- Additional modifications to `brille` allow for early identification of
  likely-out-of-memory issues when attempting to interpolate at too many
  Q points simultaneously. Future updates to brille/Horace/OptFunction
  should better handle this situation.